### PR TITLE
Validate Length of Encryption Key

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,5 +9,9 @@ func (c *Config) Validate() error {
 		return Error("encryption key is empty")
 	}
 
+	if len(c.EncryptionKey) != 16 && len(c.EncryptionKey) != 24 && len(c.EncryptionKey) != 32 {
+		return Error("invalid encryption key")
+	}
+
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -29,6 +29,33 @@ func TestValidate(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "Test invalid encryption key (16 bytes)",
+			args: args{
+				c: &Config{
+					EncryptionKey: "secret",
+				},
+			},
+			want: ErrInvalidEncryptionKey,
+		},
+		{
+			name: "Test invalid encryption key (24 bytes)",
+			args: args{
+				c: &Config{
+					EncryptionKey: "secretpasswordnotgood",
+				},
+			},
+			want: ErrInvalidEncryptionKey,
+		},
+		{
+			name: "Test invalid encryption key (32 bytes)",
+			args: args{
+				c: &Config{
+					EncryptionKey: "secretsecretpasswordnotgoodevennow",
+				},
+			},
+			want: ErrInvalidEncryptionKey,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/safeguard.go
+++ b/safeguard.go
@@ -13,6 +13,8 @@ import (
 var (
 	// ErrEncryptionKeyEmpty is returned when the EncryptionKey is empty.
 	ErrEncryptionKeyEmpty = Error("encryption key is empty")
+	// ErrInvalidEncryptionKey is returned when the EncryptionKey is invalid.
+	ErrInvalidEncryptionKey = Error("invalid encryption key")
 )
 
 type Safeguard struct {


### PR DESCRIPTION
This pull request updates the Config validation to check if the encryption key is the appropriate length (16, 24, or 32 bytes), returning an error if it is invalid.